### PR TITLE
Dataset: Fix typo and case error

### DIFF
--- a/v0.3.0/Azure-NDmv4-A100/dataset_description.md
+++ b/v0.3.0/Azure-NDmv4-A100/dataset_description.md
@@ -4,7 +4,7 @@ The dataset is generated from 729 ndmv4 nodes' Superbench v0.3 raw results.
 
 The results are the averaged data among the same type of metrics. For example, we aggregate IB loopback bandwidth from 8 NICs together and do the average, aggregate kernel launch time from 8 GPUs together and do the average, aggregate disk IO latency from 8 disks together and do the average, etc.
 
-Included benchamrks: 
+Included benchmarks: 
 
 -   kernel-launch
 -   gemm-flops
@@ -24,6 +24,6 @@ Included benchamrks:
 -   vgg_models
 -   gpu-sm-copy-bw
 
-Missed benchamrks: 
+Missed benchmarks: 
 
 -  disk-benchmark

--- a/v0.3.0/Azure-NDmv4-A100/dataset_description.md
+++ b/v0.3.0/Azure-NDmv4-A100/dataset_description.md
@@ -1,6 +1,6 @@
-# Azure NDmv4 Golden dataset on Superbench v0.3
+# Azure NDmv4 Golden dataset on SuperBench v0.3
 
-The dataset is generated from 729 NDmv4 nodes' Superbench v0.3 raw results.
+The dataset is generated from 729 NDmv4 nodes' SuperBench v0.3 raw results.
 
 The results are the averaged data among the same type of metrics. For example, we aggregate IB loopback bandwidth from 8 NICs together and do the average, aggregate kernel launch time from 8 GPUs together and do the average, aggregate disk IO latency from 8 disks together and do the average, etc.
 

--- a/v0.3.0/Azure-NDmv4-A100/dataset_description.md
+++ b/v0.3.0/Azure-NDmv4-A100/dataset_description.md
@@ -1,6 +1,6 @@
 # Azure NDmv4 Golden dataset on Superbench v0.3
 
-The dataset is generated from 729 ndmv4 nodes' Superbench v0.3 raw results.
+The dataset is generated from 729 NDmv4 nodes' Superbench v0.3 raw results.
 
 The results are the averaged data among the same type of metrics. For example, we aggregate IB loopback bandwidth from 8 NICs together and do the average, aggregate kernel launch time from 8 GPUs together and do the average, aggregate disk IO latency from 8 disks together and do the average, etc.
 

--- a/v0.3.0/Azure-NDv4-A100/dataset_description.md
+++ b/v0.3.0/Azure-NDv4-A100/dataset_description.md
@@ -1,6 +1,6 @@
 # Azure NDv4 Golden dataset on Superbench v0.3
 
-The dataset is generated from 1939 ndv4 nodes' Superbench v0.3 raw results.
+The dataset is generated from 1939 NDv4 nodes' Superbench v0.3 raw results.
 
 The results are the averaged data among the same type of metrics. For example, we aggregate IB loopback bandwidth from 8 NICs together and do the average, aggregate kernel launch time from 8 GPUs together and do the average, aggregate disk IO latency from 8 disks together and do the average, etc.
 

--- a/v0.3.0/Azure-NDv4-A100/dataset_description.md
+++ b/v0.3.0/Azure-NDv4-A100/dataset_description.md
@@ -1,6 +1,6 @@
-# Azure NDv4 Golden dataset on Superbench v0.3
+# Azure NDv4 Golden dataset on SuperBench v0.3
 
-The dataset is generated from 1939 NDv4 nodes' Superbench v0.3 raw results.
+The dataset is generated from 1939 NDv4 nodes' SuperBench v0.3 raw results.
 
 The results are the averaged data among the same type of metrics. For example, we aggregate IB loopback bandwidth from 8 NICs together and do the average, aggregate kernel launch time from 8 GPUs together and do the average, aggregate disk IO latency from 8 disks together and do the average, etc.
 

--- a/v0.3.0/Azure-NDv4-A100/dataset_description.md
+++ b/v0.3.0/Azure-NDv4-A100/dataset_description.md
@@ -4,7 +4,7 @@ The dataset is generated from 1939 ndv4 nodes' Superbench v0.3 raw results.
 
 The results are the averaged data among the same type of metrics. For example, we aggregate IB loopback bandwidth from 8 NICs together and do the average, aggregate kernel launch time from 8 GPUs together and do the average, aggregate disk IO latency from 8 disks together and do the average, etc.
 
-Included benchamrks: 
+Included benchmarks: 
 
 -   kernel-launch
 -   gemm-flops
@@ -17,7 +17,7 @@ Included benchamrks:
 -   disk-benchmark
 
 
-Missed benchamrks: 
+Missed benchmarks: 
 
 -  cublas_function
 -  cudnn_function

--- a/v0.4.0/Azure-NDmv4-A100/dataset_description.md
+++ b/v0.4.0/Azure-NDmv4-A100/dataset_description.md
@@ -1,6 +1,6 @@
 # Azure NDmv4 Golden dataset on Superbench v0.4
 
-The dataset is generated from 729 ndmv4 nodes' Superbench v0.4 raw results.
+The dataset is generated from 729 NDmv4 nodes' Superbench v0.4 raw results.
 
 The results are the averaged data among the same type of metrics. For example, we aggregate IB loopback bandwidth from 8 NICs together and do the average, aggregate kernel launch time from 8 GPUs together and do the average, aggregate disk IO latency from 8 disks together and do the average, etc.
 

--- a/v0.4.0/Azure-NDmv4-A100/dataset_description.md
+++ b/v0.4.0/Azure-NDmv4-A100/dataset_description.md
@@ -1,6 +1,6 @@
-# Azure NDmv4 Golden dataset on Superbench v0.4
+# Azure NDmv4 Golden dataset on SuperBench v0.4
 
-The dataset is generated from 729 NDmv4 nodes' Superbench v0.4 raw results.
+The dataset is generated from 729 NDmv4 nodes' SuperBench v0.4 raw results.
 
 The results are the averaged data among the same type of metrics. For example, we aggregate IB loopback bandwidth from 8 NICs together and do the average, aggregate kernel launch time from 8 GPUs together and do the average, aggregate disk IO latency from 8 disks together and do the average, etc.
 

--- a/v0.4.0/Azure-NDmv4-A100/dataset_description.md
+++ b/v0.4.0/Azure-NDmv4-A100/dataset_description.md
@@ -4,7 +4,7 @@ The dataset is generated from 729 ndmv4 nodes' Superbench v0.4 raw results.
 
 The results are the averaged data among the same type of metrics. For example, we aggregate IB loopback bandwidth from 8 NICs together and do the average, aggregate kernel launch time from 8 GPUs together and do the average, aggregate disk IO latency from 8 disks together and do the average, etc.
 
-Included benchamrks: 
+Included benchmarks: 
 
 -   kernel-launch
 -   gemm-flops
@@ -23,7 +23,7 @@ Included benchamrks:
 -   densenet_models
 -   vgg_models
 
-Missed benchamrks: 
+Missed benchmarks: 
 
 -  disk-benchmark
 -  gpu-copy-bw

--- a/v0.4.0/Azure-NDv4-A100/dataset_description.md
+++ b/v0.4.0/Azure-NDv4-A100/dataset_description.md
@@ -1,6 +1,6 @@
-# Azure NDv4 Golden dataset on Superbench v0.4
+# Azure NDv4 Golden dataset on SuperBench v0.4
 
-The dataset is generated from 1939 NDv4 nodes' Superbench v0.4 raw results.
+The dataset is generated from 1939 NDv4 nodes' SuperBench v0.4 raw results.
 
 The results are the averaged data among the same type of metrics. For example, we aggregate IB loopback bandwidth from 8 NICs together and do the average, aggregate kernel launch time from 8 GPUs together and do the average, aggregate disk IO latency from 8 disks together and do the average, etc.
 

--- a/v0.4.0/Azure-NDv4-A100/dataset_description.md
+++ b/v0.4.0/Azure-NDv4-A100/dataset_description.md
@@ -1,6 +1,6 @@
 # Azure NDv4 Golden dataset on Superbench v0.4
 
-The dataset is generated from 1939 ndv4 nodes' Superbench v0.4 raw results.
+The dataset is generated from 1939 NDv4 nodes' Superbench v0.4 raw results.
 
 The results are the averaged data among the same type of metrics. For example, we aggregate IB loopback bandwidth from 8 NICs together and do the average, aggregate kernel launch time from 8 GPUs together and do the average, aggregate disk IO latency from 8 disks together and do the average, etc.
 

--- a/v0.4.0/Azure-NDv4-A100/dataset_description.md
+++ b/v0.4.0/Azure-NDv4-A100/dataset_description.md
@@ -4,7 +4,7 @@ The dataset is generated from 1939 ndv4 nodes' Superbench v0.4 raw results.
 
 The results are the averaged data among the same type of metrics. For example, we aggregate IB loopback bandwidth from 8 NICs together and do the average, aggregate kernel launch time from 8 GPUs together and do the average, aggregate disk IO latency from 8 disks together and do the average, etc.
 
-Included benchamrks: 
+Included benchmarks: 
 
 -   kernel-launch
 -   gemm-flops
@@ -17,7 +17,7 @@ Included benchamrks:
 -   disk-benchmark
 
 
-Missed benchamrks: 
+Missed benchmarks: 
 
 -  cublas_function
 -  cudnn_function


### PR DESCRIPTION
1. fix typo of benchmarks
2. revise "ndmv4" to "NDmv4"
3. revise "ndv4" to "NDv4"